### PR TITLE
 add first_name and last_name field of tt_address to the default

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -54,7 +54,7 @@ $TYPO3_CONF_VARS['EXTCONF'][$_EXTKEY]['sendPerCycle'] = $extConf['sendPerCycle']
 /**
  * Default recipient field list:
  */
-$TYPO3_CONF_VARS['EXTCONF'][$_EXTKEY]['defaultRecipFields'] = 'uid,name,title,email,phone,www,address,company,city,zip,country,fax,firstname';
+$TYPO3_CONF_VARS['EXTCONF'][$_EXTKEY]['defaultRecipFields'] = 'uid,name,title,email,phone,www,address,company,city,zip,country,fax,firstname,first_name,last_name';
 
 /**
  * Additional DB fields of the recipient:


### PR DESCRIPTION
usable fields in markers.

I know that Its possible to add this over $extConf['addRecipFields'] but

tt_address default values (since a long time) is tt_address.first_name and first_name.last_name and not the compound tt_address.name anymore

so please update this..

thanks