### PR TITLE
[BUGFIX] Don't schedule draft mail if fetching new content failed

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <?php
 namespace DirectMailTeam\DirectMail;
 

--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 <?php
 namespace DirectMailTeam\DirectMail;
 
@@ -15,11 +16,11 @@ namespace DirectMailTeam\DirectMail;
  */
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Backend\Utility\IconUtility;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Backend\Utility\IconUtility;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 
 /**
@@ -1097,10 +1098,11 @@ class DirectMailUtility
      *
      * @param array $row Directmail DB record
      * @param array $params Any default parameters (usually the ones from pageTSconfig)
+     * @param bool $returnArray Return error or warning message as array instead of string
      *
      * @return string Error or warning message during fetching the content
      */
-    public static function fetchUrlContentsForDirectMailRecord(array $row, array $params)
+    public static function fetchUrlContentsForDirectMailRecord(array $row, array $params, $returnArray = false)
     {
         $theOutput = '';
         $errorMsg = array();
@@ -1207,8 +1209,11 @@ class DirectMailUtility
             );
             $theOutput .= $flashMessage->render();
         }
-
-        return $theOutput;
+        if ($returnArray) {
+            return array('errors' => $errorMsg, 'warnings' => $warningMsg);
+        } else {
+            return $theOutput;
+        }
     }
 
 

--- a/Classes/Scheduler/MailFromDraft.php
+++ b/Classes/Scheduler/MailFromDraft.php
@@ -71,6 +71,11 @@ class MailFromDraft extends AbstractTask
             // set the right type (3 => 1, 2 => 0)
             $draftRecord['type'] -= 2;
 
+                // check if domain record is set
+            if ((TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI) && (int)$draftRecord['type'] !== 1 && empty($draftRecord['use_domain'])) {
+                throw new \Exception('No domain record set!');
+            }
+
                 // Insert the new dmail record into the DB
             $GLOBALS['TYPO3_DB']->exec_INSERTquery('sys_dmail', $draftRecord);
             $this->dmailUid = $GLOBALS['TYPO3_DB']->sql_insert_id();

--- a/Classes/Scheduler/MailFromDraft.php
+++ b/Classes/Scheduler/MailFromDraft.php
@@ -14,10 +14,10 @@ namespace DirectMailTeam\DirectMail\Scheduler;
  * The TYPO3 project - inspiring people to share!
  */
 
-use \TYPO3\CMS\Backend\Utility\BackendUtility;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
-use \TYPO3\CMS\Scheduler\Task\AbstractTask;
-use \DirectMailTeam\DirectMail\DirectMailUtility;
+use DirectMailTeam\DirectMail\DirectMailUtility;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Task\AbstractTask;
 
 /**
  * Class tx_directmail_Scheduler_MailFromDraft
@@ -85,7 +85,12 @@ class MailFromDraft extends AbstractTask
                 // fetch the cloned record
             $mailRecord = BackendUtility::getRecord('sys_dmail', $this->dmailUid);
 
-            DirectMailUtility::fetchUrlContentsForDirectMailRecord($mailRecord, $defaultParams);
+                // fetch mail content
+            $result = DirectMailUtility::fetchUrlContentsForDirectMailRecord($mailRecord, $defaultParams, TRUE);
+
+            if ($result['errors'] !== array()) {
+                throw new \Exception('Failed to fetch contents: ' . implode(', ', $result['errors']));
+            }
 
             $mailRecord = BackendUtility::getRecord('sys_dmail', $this->dmailUid);
             if ($mailRecord['mailContent'] && $mailRecord['renderedsize'] > 0) {


### PR DESCRIPTION
If fetching of new content failed throw an exception with the error
from DirectMailUtility::fetchUrlContentsForDirectMailRecord().

This prevents old mail being send to the receivers. And makes the
error visible for the admin in the BE.