### PR TITLE
[BUGFIX] Fix issue with "extractHyperLinks"

### DIFF
--- a/Tests/Unit/Dmailer/DirectMailEngineTest.php
+++ b/Tests/Unit/Dmailer/DirectMailEngineTest.php
@@ -1,33 +1,26 @@
 <?php
 namespace DirectMailTeam\DirectMail\Tests\Unit\Mailer;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2013 Bernhard Kraft <kraft@webconsulting.at>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 /**
- * Testcase for class "dmailer"
+ * Testcase for class "DirectMailTeam\DirectMail\Dmailer"
  *
  * @author Bernhard Kraft <kraft@webconsulting.at>
+ *
+ * @package 	TYPO3
+ * @subpackage 	tx_directmail
  */
 class DirectMailEngineTest extends \TYPO3\CMS\Core\Tests\UnitTestCase
 {
@@ -81,7 +74,7 @@ class DirectMailEngineTest extends \TYPO3\CMS\Core\Tests\UnitTestCase
                 )
             ),
             'absolute url (fails currently, #54459)' => array('
-				This is a <a name=http://google.com href="http://google.com">simple</a> test',
+				This is a <a title="Browse to http://google.com for more information" href="http://google.com">simple</a> test',
                 'http://www.server.com/',
                 array(
                     array(


### PR DESCRIPTION
For some special cases as shown by the unit tests the method
"extractHyperLinks" fails to properly extract the appropriate
values. The unit tests fail.

This patch solves the issue and makes the unit tests working
again.

Resolves: https://github.com/kartolo/direct_mail/issues/12
Releases: master