### PR TITLE
Updated PHP version requirement

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -36,7 +36,7 @@ $EM_CONF[$_EXTKEY] = array(
         'depends' => array(
             'cms' => '',
             'tt_address' => '',
-            'php' => '5.3.0',
+            'php' => '5.5.0',
             'typo3' => '7.6.0-7.6.99',
             'jumpurl' => '7.6.0-7.6.99',
         ),


### PR DESCRIPTION
As the extension uses the "::class" keyword/operator the PHP version requirement has to get raised to 5.5