### PR TITLE
[FEATURE] Add a new hook for link reponse output

### DIFF
--- a/Classes/Module/Statistics.php
+++ b/Classes/Module/Statistics.php
@@ -839,7 +839,24 @@ class Statistics extends \TYPO3\CMS\Backend\Module\BaseScriptClass
 
         if ($urlCounter['total']) {
             $output .= '<br /><h2>' . $this->getLanguageService()->getLL('stats_response_link') . '</h2>';
-            $output .= DirectMailUtility::formatTable($tblLines, array('nowrap', 'nowrap width="100"', 'nowrap width="100"', 'nowrap', 'nowrap', 'nowrap', 'nowrap'), 1, array(1, 0, 0, 0, 0, 0, 1));
+
+            /**
+             * Hook for cmd_stats_linkResponses
+             */
+            if (is_array ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['direct_mail']['mod4']['cmd_stats_linkResponses'])) {
+                $hookObjectsArr = array();
+                foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['direct_mail']['mod4']['cmd_stats_linkResponses'] as $classRef) {
+                    $hookObjectsArr[] = &GeneralUtility::getUserObj($classRef);
+                }
+
+                foreach($hookObjectsArr as $hookObj) {
+                    if (method_exists($hookObj, 'cmd_stats_linkResponses')) {
+                        $output .= $hookObj->cmd_stats_linkResponses($tblLines, $this);
+                    }
+                }
+            } else {
+                $output .= DirectMailUtility::formatTable($tblLines, array('nowrap', 'nowrap width="100"', 'nowrap width="100"', 'nowrap', 'nowrap', 'nowrap', 'nowrap'), 1, array(1, 0, 0, 0, 0, 0, 1));         
+            }
         }
 
 

--- a/Documentation/Configuration/Hooks/Index.rst
+++ b/Documentation/Configuration/Hooks/Index.rst
@@ -51,6 +51,21 @@ cmd_stats
    Description
          This hook can be used to influence the output of the overall statistic output
 
+.. _hooks_cmd_stats_linkResponses:
+cmd_stats_linkResponses
+'''''''''
+
+.. container:: table-row
+
+   Property
+         ``$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['direct_mail']['mod4']['cmd_stats_linkResponses']``
+
+   Method
+         ``cmd_stats_linkResponses``
+
+   Description
+         This hook can be used to influence the output of the statistics section "link responses" 
+
 .. _hooks_renderCType:
 renderCType
 '''''''''''


### PR DESCRIPTION
This adds a simple hook to allow a more fine-grained control of the statistics link response output.
