### PR TITLE
Optionally use FAL when rendering images for text format newsletters.

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -25,3 +25,5 @@ UseHttpToFetch = 0
 	# cat=basic/dev/1000; type=user[DirectMailTeam\DirectMail\Utility\TsParserExt->displayMessage]; label=LLL:EXT:direct_mail/Resources/Private/Language/locallang_mod2-6.xlf:update_option
 updateMessage=0
 
+  # cat=basic/enable; type=boolean; label=Use FAL when rendering images in Text format
+useFal=0

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -82,6 +82,11 @@ $TYPO3_CONF_VARS['EXTCONF'][$_EXTKEY]['cronInt'] = $extConf['cronInt'];
 $TYPO3_CONF_VARS['EXTCONF'][$_EXTKEY]['UseHttpToFetch'] = $extConf['UseHttpToFetch'];
 
 /**
+ * Use FAL when rendering images in plain text format
+ */
+$TYPO3_CONF_VARS['EXTCONF'][$_EXTKEY]['useFal'] = $extConf['useFal'];
+
+/**
  * Enable the use of News plain text rendering hook:
  */
 if ($extConf['enablePlainTextNews']) {

--- a/pi1/class.tx_directmail_pi1.php
+++ b/pi1/class.tx_directmail_pi1.php
@@ -239,11 +239,20 @@ class tx_directmail_pi1 extends AbstractPlugin
      */
     public function getImages()
     {
+    		global $TYPO3_CONF_VARS;
+
         $imagesArray = array();
-        $this->getImagesStandard($imagesArray);
-        if (ExtensionManagementUtility::isLoaded('dam')) {
+
+        if ($TYPO3_CONF_VARS['EXTCONF']['direct_mail']['useFal']) {
+					$this->getImagesFromFal($imagesArray);
+
+				} else {
+        	$this->getImagesStandard($imagesArray);
+
+        	if (ExtensionManagementUtility::isLoaded('dam')) {
             $this->getImagesFromDam($imagesArray);
-        }
+        	}
+				}
 
         $images = $this->renderImages($imagesArray, !$this->cObj->data['image_zoom']?$this->cObj->data['image_link']:'', $this->cObj->data['imagecaption']);
 
@@ -267,6 +276,21 @@ class tx_directmail_pi1 extends AbstractPlugin
             }
         }
     }
+
+    /**
+		 * Get images from FAL and store them in $imagesArray
+		 *
+	   * @param array $imagesArray
+	   */
+    public function getImagesFromFal(array &$imagesArray)
+		{
+			$fileRepository = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\FileRepository::class);
+			$fileObjects = $fileRepository->findByRelation('tt_content', 'image', $this->cObj->data['uid']);
+
+			foreach ($fileObjects as $fileObject) {
+				$imagesArray[] = $this->siteUrl . $fileObject->getPublicUrl();
+			}
+		}
 
     /**
      * Get images from DAM and store this images to $images_arr


### PR DESCRIPTION
This patch addresses the problem that for plain text newsletters images that are stored in FAL are not rendered correctly. Originally reported here: https://forge.typo3.org/issues/62125.