### PR TITLE
[BUGFIX] set empty value for attachment

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -967,7 +967,8 @@ class DirectMailUtility
             'authcode_fieldList'    => $parameters['authcode_fieldList'],
             'sendOptions'            => $GLOBALS['TCA']['sys_dmail']['columns']['sendOptions']['config']['default'],
             'long_link_rdct_url'    => self::getUrlBase($parameters['use_domain']),
-            'sys_language_uid' => (int)$sysLanguageUid
+            'sys_language_uid' => (int)$sysLanguageUid,
+            'attachment' => ''
         );
 
         if ($newRecord['sys_language_uid'] > 0) {


### PR DESCRIPTION
wenn SQL is set to strict, SQL shows error since attachment is blob and it needs default value

Resolves #52