### PR TITLE
Add user-agent when fetching content of a page

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -1181,7 +1181,7 @@ class DirectMailUtility
         $htmlmail->includeMedia = $row['includeMedia'];
 
         if ($plainTextUrl) {
-            $mailContent = GeneralUtility::getURL(self::addUserPass($plainTextUrl, $params));
+            $mailContent = GeneralUtility::getURL(self::addUserPass($plainTextUrl, $params), 0, array('User-Agent: Direct Mail'));
             $htmlmail->addPlain($mailContent);
             if (!$mailContent || !$htmlmail->theParts['plain']['content']) {
                 $errorMsg[] = $GLOBALS["LANG"]->getLL('dmail_no_plain_content');


### PR DESCRIPTION
Sometimes the server security policy doesn't allow to fetch pages when user-agent is not given. With this patch we can add the user-agent when fetching the content  of a page.

Related to #67 