### PR TITLE
[TASK] Use larger select field for multiple mail groups

### DIFF
--- a/Classes/Module/Dmail.php
+++ b/Classes/Module/Dmail.php
@@ -1080,7 +1080,7 @@ class Dmail extends BaseScriptClass
                 $result = $this->cmd_compileMailGroup($recipientGroups);
                 $queryInfo = $result['queryInfo'];
 
-                $distributionTime = intval(GeneralUtility::_GP('send_mail_datetime'));
+                $distributionTime = strtotime(GeneralUtility::_GP('send_mail_datetime'));
                 if ($distributionTime < time()) {
                     $distributionTime = time();
                 }

--- a/Classes/Module/Dmail.php
+++ b/Classes/Module/Dmail.php
@@ -931,7 +931,7 @@ class Dmail extends BaseScriptClass
                 $groupInput .= '<em>disabled</em>';
             }
         } else {
-            $groupInput = '<select multiple="multiple" name="mailgroup_uid[]" '.($hookSelectDisabled ? 'disabled' : '').'>'.implode(chr(10),$opt).'</select>';
+            $groupInput = '<select class="form-control" size="20" multiple="multiple" name="mailgroup_uid[]" '.($hookSelectDisabled ? 'disabled' : '').'>'.implode(chr(10),$opt).'</select>';
         }
             // Set up form:
         $msg = "";


### PR DESCRIPTION
This renders a larger select field for multiple mail groups. We use a TYPO3 typical CSS class and the size attribute to modify the select field.