### PR TITLE
[FIX] Use correct function to parse string to timestamp

### DIFF
--- a/Classes/Module/Dmail.php
+++ b/Classes/Module/Dmail.php
@@ -1080,7 +1080,7 @@ class Dmail extends BaseScriptClass
                 $result = $this->cmd_compileMailGroup($recipientGroups);
                 $queryInfo = $result['queryInfo'];
 
-                $distributionTime = intval(GeneralUtility::_GP('send_mail_datetime'));
+                $distributionTime = strtotime(GeneralUtility::_GP('send_mail_datetime'));
                 if ($distributionTime < time()) {
                     $distributionTime = time();
                 }


### PR DESCRIPTION
When saving the distribution time it now parses to correct timestamp. Tested in TYPO3 8.