### PR TITLE
[BUGFIX] fix typo3/cms-core version range in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "issues": "https://forge.typo3.org/projects/extension-direct_mail"
   },
   "require": {
-    "typo3/cms-core": ">=7.6,<8.0",
+    "typo3/cms-core": ">=7.6,<9.0",
     "typo3-ter/jumpurl": ">=7.6",
     "typo3-ter/tt-address": "^3.2"
   },


### PR DESCRIPTION
Allow installation via composer in typo3 v8.7 again. 