### PR TITLE
No /tmp directory on windows systems

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -1223,9 +1223,6 @@ class DirectMailUtility
             $htmlmail->theParts['messageid'] = $htmlmail->messageid;
             $mailContent = base64_encode(serialize($htmlmail->theParts));
 
-            // !ian save last dmail source in tmp for debug
-            // file_put_contents('/tmp/dmail.php', var_export($htmlmail->theParts, true));
-
             $updateData = array(
                 'issent'             => 0,
                 'charset'            => $htmlmail->charset,

--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -1224,7 +1224,7 @@ class DirectMailUtility
             $mailContent = base64_encode(serialize($htmlmail->theParts));
 
             // !ian save last dmail source in tmp for debug
-            file_put_contents('/tmp/dmail.php', var_export($htmlmail->theParts, true));
+            // file_put_contents('/tmp/dmail.php', var_export($htmlmail->theParts, true));
 
             $updateData = array(
                 'issent'             => 0,


### PR DESCRIPTION
As there is no /tmp directory on windows systems debug output results in an error.
Core: Error handler (BE): PHP Warning: file_put_contents(/tmp/dmail.php): failed to open stream: No such file or directory in C:\wwwroot\...\typo3conf\ext\direct_mail\Classes\DirectMailUtility.php line 1227