### PR TITLE
Fix additional fields in bounce task

### DIFF
--- a/Classes/Scheduler/AnalyzeBounceMailAdditionalFields.php
+++ b/Classes/Scheduler/AnalyzeBounceMailAdditionalFields.php
@@ -63,8 +63,8 @@ class AnalyzeBounceMailAdditionalFields implements AdditionalFieldProviderInterf
         $passwordHTML = '<input type="password" name="tx_scheduler[bouncePassword]" value="' . ($task ? $task->getPassword() : '') . '"/>';
         $maxProcessedHTML = '<input type="text" name="tx_scheduler[bounceProcessed]" value="' . ($task ? $task->getMaxProcessed() : '') . '"/>';
         $serviceHTML = '<select name="tx_scheduler[bounceService]" id="bounceService">' .
-            '<option value="imap" ' . ($task->getService == 'imap'? 'selected="selected"' : '') . '>IMAP</option>' .
-            '<option value="pop3" ' . ($task->getService == 'pop3'? 'selected="selected"' : '') . '>POP3</option>' .
+            '<option value="imap" ' . ($task->getService() === 'imap'? 'selected="selected"' : '') . '>IMAP</option>' .
+            '<option value="pop3" ' . ($task->getService() === 'pop3'? 'selected="selected"' : '') . '>POP3</option>' .
             '</select>';
 
         $additionalFields = array();


### PR DESCRIPTION
The additional field »service« in the task for the bounce
mail handling was not retrieved correctly before and
caused the form to preset “IMAP” every time.

Grab the correct object method to use the existing value.