### PR TITLE
README: Remove Forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
 # Direct Mail
 
-The Direct Mail implements advanced newsletter mailer system for the [TYPO3 CMS](http://typo3.org). This extension provides not only a system for sending a newsletter from TYPO3 CMS, but also personalizing it and collect some statistics.
+The »Direct Mail« extension implements an advanced newsletter mailer system for the [TYPO3 CMS](https://typo3.org). This extension provides not only a system for sending a newsletter from TYPO3 CMS, but also personalizing it and collect some statistics.
 
-The extension creates and send a newsletter based on TYPO3 page, so that you can create newsletter layout as you create website layout.
+The extension builds a newsletter based on a TYPO3 page, so that you can create newsletter layout the same way you create a website layout. It also lets editors select between different recipient groups for each newsletter.
+
+The extension provides several scheduler tasks to let integrators control when and how much newsletters are send, and to analyze bounce mails.
+
+## Installation
+
+- https://extensions.typo3.org/extension/direct_mail/
+
+- https://packagist.org/packages/directmailteam/direct-mail
 
 ## Documentation and support
 
 -  **Documentation**
 
    https://docs.typo3.org/typo3cms/extensions/direct_mail/
-
 
 -  **Slack channel**
 
@@ -19,12 +26,16 @@ The extension creates and send a newsletter based on TYPO3 page, so that you can
 
 ## Contributing
 
-You can contribute to this project by reporting any issue you found here in github or on https://forge.typo3.org/projects/extension-direct_mail/
+You can contribute to this project by [creating issues](https://github.com/kartolo/direct_mail/issues) 
+and/or sending pull requests.
 
-You can also contributing any code by:
-
-1. Fork the repository on Github
-2. Clone repository
-3. Make your changes
-4. Commit your changes to your fork. In your commit message refer to the issue number if there is already one, e.g. `[BUGFIX] short description of fix (resolves #4711)`
-5. Submit a Pull Request using GitHub (here are some hints on [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request))
+  1. Create an issue or look for existing ones
+  1. Fork the repository on Github
+  1. Clone the repository, create a new branch based on the "develop" branch
+  1. Make your changes, commit your changes to your fork 
+     
+     In your commit message refer to the issue number if there is already one, e.g. `[BUGFIX] Short description of fix (resolves #4711)`
+     
+     PS: here are some hints on [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)
+  1. Submit a pull request using GitHub 
+  1. Wait for check backs or the final merge


### PR DESCRIPTION
Since Forge is [not used anymore](https://forge.typo3.org/issues/82947#note-2) I quickly updated this in the README:

* Remove link to forge
* Add links to TER & Packagist
* Explain "develop" branch in contribution guideline