### PR TITLE
[BUGFIX] for Typo3 v9 compatibility #138

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -226,7 +226,10 @@ class DirectMailUtility
         } else {
             $switchTable = $table;
         }
+		
+		$pidArray = GeneralUtility::intExplode(',', $pidList);
 
+		/** @var \TYPO3\CMS\Core\Database\Connection $connection */
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable($table);
         $queryBuilder = $connection->createQueryBuilder();
@@ -259,7 +262,7 @@ class DirectMailUtility
                     ->from($table, $table)
                     ->andWhere(
                         $queryBuilder->expr()->andX()
-                            ->add($queryBuilder->expr()->in('fe_groups.pid', $queryBuilder->createNamedParameter($pidList)))
+                            ->add($queryBuilder->expr()->in('fe_groups.pid', $queryBuilder->createNamedParameter($pidArray, Connection::PARAM_INT_ARRAY)))
                             ->add('INSTR( CONCAT(\',\',fe_users.usergroup,\',\'),CONCAT(\',\',fe_groups.uid ,\',\') )')
                             ->add(
                                 $queryBuilder->expr()->neq($switchTable . '.email', $queryBuilder->createNamedParameter(''))
@@ -275,7 +278,7 @@ class DirectMailUtility
                     ->from($switchTable)
                     ->andWhere(
                         $queryBuilder->expr()->andX()
-                            ->add($queryBuilder->expr()->in($switchTable . '.pid', $queryBuilder->createNamedParameter($pidList)))
+                            ->add($queryBuilder->expr()->in($switchTable . '.pid', $queryBuilder->createNamedParameter($pidArray, Connection::PARAM_INT_ARRAY)))
                             ->add(
                                 $queryBuilder->expr()->neq($switchTable . '.email', $queryBuilder->createNamedParameter(''))
                             )
@@ -301,7 +304,7 @@ class DirectMailUtility
                     )
                     ->andWhere(
                         $queryBuilder->expr()->andX()
-                            ->add($queryBuilder->expr()->in('fe_groups.pid', $queryBuilder->createNamedParameter($pidList)))
+                            ->add($queryBuilder->expr()->in('fe_groups.pid', $queryBuilder->createNamedParameter($pidArray, Connection::PARAM_INT_ARRAY)))
                             ->add('INSTR( CONCAT(\',\',fe_users.usergroup,\',\'),CONCAT(\',\',fe_groups.uid ,\',\') )')
                             ->add($queryBuilder->expr()->eq('mm_1.uid_foreign', $queryBuilder->quoteIdentifier('g_mm.uid_foreign')))
                             ->add($queryBuilder->expr()->eq('sys_dmail_group.uid', $queryBuilder->quoteIdentifier('g_mm.uid_local')))
@@ -319,7 +322,7 @@ class DirectMailUtility
                     ->selectLiteral('DISTINCT ' . $switchTable . '.uid', $switchTable . '.email')
                     ->from('sys_dmail_group', 'sys_dmail_group')
                     ->from('sys_dmail_group_category_mm', 'g_mm')
-                    ->from($mmTable, 'mm_1')
+                    ->from($mmTable, 'mm_1') 
                     ->leftJoin(
                         'mm_1',
                         $table,
@@ -328,7 +331,7 @@ class DirectMailUtility
                     )
                     ->andWhere(
                         $queryBuilder->expr()->andX()
-                            ->add($queryBuilder->expr()->in($switchTable . '.pid', $queryBuilder->createNamedParameter($pidList)))
+                            ->add($queryBuilder->expr()->in($switchTable . '.pid', $queryBuilder->createNamedParameter($pidArray, Connection::PARAM_INT_ARRAY)))
                             ->add($queryBuilder->expr()->eq('mm_1.uid_foreign', $queryBuilder->quoteIdentifier('g_mm.uid_foreign')))
                             ->add($queryBuilder->expr()->eq('sys_dmail_group.uid', $queryBuilder->quoteIdentifier('g_mm.uid_local')))
                             ->add($queryBuilder->expr()->eq('sys_dmail_group.uid', $queryBuilder->createNamedParameter($groupUid, \PDO::PARAM_INT)))

--- a/Configuration/TCA/sys_dmail.php
+++ b/Configuration/TCA/sys_dmail.php
@@ -8,7 +8,7 @@ return array(
         'prependAtCopy' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.prependAtCopy',
         'title' => 'LLL:EXT:direct_mail/Resources/Private/Language/locallang_tca.xlf:sys_dmail',
         'delete' => 'deleted',
-        'iconfile' => TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('direct_mail') . 'Resources/Public/Icons/mail.gif',
+        'iconfile' => 'EXT:direct_mail/Resources/Public/Icons/mail.gif',
         'type' => 'type',
         'useColumnsForDefaultValues' => 'from_email,from_name,replyto_email,replyto_name,organisation,priority,encoding,charset,sendOptions,type',
         'dividers2tabs' => true,

--- a/Configuration/TCA/sys_dmail_category.php
+++ b/Configuration/TCA/sys_dmail_category.php
@@ -15,7 +15,7 @@ return array(
         'enablecolumns' => array(
             'disabled' => 'hidden',
         ),
-        'iconfile' => TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('direct_mail') . 'Resources/Public/Icons/icon_tx_directmail_category.gif',
+        'iconfile' => 'EXT:direct_mail/Resources/Public/Icons/icon_tx_directmail_category.gif',
     ),
     'interface' => array(
         'showRecordFieldList' => 'hidden,category'

--- a/Configuration/TCA/sys_dmail_group.php
+++ b/Configuration/TCA/sys_dmail_group.php
@@ -8,7 +8,7 @@ return array(
         'prependAtCopy' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.prependAtCopy',
         'title' => 'LLL:EXT:direct_mail/Resources/Private/Language/locallang_tca.xlf:sys_dmail_group',
         'delete' => 'deleted',
-        'iconfile' => TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('direct_mail') . 'Resources/Public/Icons/mailgroup.gif',
+        'iconfile' => 'EXT:direct_mail/Resources/Public/Icons/mailgroup.gif',
         'type' => 'type',
     ),
     'interface' => array(

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -4,7 +4,6 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
-$extPath = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY);
 
     // Category field disabled by default in backend forms.
 TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('
@@ -159,11 +158,9 @@ if (TYPO3_MODE == 'BE') {
 }
 
 
-$GLOBALS['TBE_STYLES']['spritemanager']['singleIcons']['tcarecords-pages-contains-dmail'] = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($_EXTKEY) . 'Resources/Public/Icons/ext_icon_dmail_folder.gif';
-
-if (TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('tt_address')) <= TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger('2.3.5')) {
-    include_once(TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'Configuration/TCA/Overrides/tt_address.php');
-}
+#if (TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('tt_address')) <= TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger('2.3.5')) {
+#    include_once(TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'Configuration/TCA/Overrides/tt_address.php');
+#}
 
 /** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
 $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
@@ -186,4 +183,10 @@ $iconRegistry->registerIcon(
     'direct_mail_preview_plain',
     \TYPO3\CMS\Core\Imaging\IconProvider\BitmapIconProvider::class,
     ['source' => 'EXT:' . $_EXTKEY . '/Resources/Public/Icons/preview_txt.gif']
+);
+
+$iconRegistry->registerIcon(
+    'tcarecords-pages-contains-dmail',
+    \TYPO3\CMS\Core\Imaging\IconProvider\BitmapIconProvider::class,
+    ['source' => 'EXT:' . $_EXTKEY . '/Resources/Public/Icons/ext_icon_dmail_folder.gif']
 );


### PR DESCRIPTION
- Fix installation in TYPO3 v9 LTS
- Fix compiling of Recipient List with "Include page subtree" enabled.