### PR TITLE
fix call and include non existing anymore tx_directmail_pi1 class in …

### DIFF
--- a/Classes/Hooks/TtnewsPlaintextHook.php
+++ b/Classes/Hooks/TtnewsPlaintextHook.php
@@ -15,10 +15,10 @@ namespace DirectMailTeam\DirectMail\Hooks;
  */
 
 use DirectMailTeam\DirectMail\DirectMailUtility;
+use DirectMailTeam\DirectMail\Plugin\DirectMail;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
-require_once('EXT:direct_mail/pi1/class.tx_directmail_pi1.php');
 
 /**
  * Generating plain text content of tt_news records for Direct Mails
@@ -48,7 +48,7 @@ class TtnewsPlaintextHook
     public $config = array();
     public $charWidth = 76;
     /**
-     * @var tx_directmail_pi1
+     * @var DirectMail
      */
     public $renderPlainText;
 
@@ -93,7 +93,7 @@ class TtnewsPlaintextHook
             $this->sys_language_mode = $invokingObj->sys_language_mode;
             $this->templateCode = $invokingObj->templateCode;
 
-            $this->renderPlainText = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_directmail_pi1');
+            $this->renderPlainText = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(DirectMail::class);
             $this->renderPlainText->init($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_directmail_pi1.']);
             $this->renderPlainText->cObj = $this->cObj;
             $this->renderPlainText->labelsList = 'tt_news_author_prefix,tt_news_author_date_prefix,tt_news_author_email_prefix,tt_news_short_header,tt_news_bodytext_header';


### PR DESCRIPTION
…tt_news plaintext hook

Also:
PLEASE keep tracking / updating your version number in em_conf. Now I have direct_mail 5.2.3 from typo3 ext repo and 5.2.3 from github here - one can think they're the same, but they're completely different. Please use x.y.z+1-dev or similar during first code mod after every release to avoid mistakes, thank you!