### PR TITLE
Remove deprecated cms dependency

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -34,7 +34,6 @@ $EM_CONF[$_EXTKEY] = [
     'CGLcompliance_note' => '',
     'constraints' => [
         'depends' => [
-            'cms' => '',
             'tt_address' => '4.0.0-',
             'php' => '7.2.0',
             'typo3' => '9.5.0-9.5.99',


### PR DESCRIPTION
Fix deprecated-Warning: Extension "direct_mail" defines a dependency on ext:cms, which has been removed. Please remove the dependency.