### PR TITLE
[TASK] Exclude translated pages from BE page navigation

### DIFF
--- a/Classes/Module/NavFrame.php
+++ b/Classes/Module/NavFrame.php
@@ -210,6 +210,12 @@ class NavFrame
                     )
                 )
             )
+            ->andWhere(
+                $queryBuilder->expr()->eq(
+                    'sys_language_uid',
+                    '0'
+                )
+            )
             ->orderBy('title')
             ->execute();
 

--- a/Configuration/TCA/sys_dmail.php
+++ b/Configuration/TCA/sys_dmail.php
@@ -11,11 +11,7 @@ return [
         'iconfile' => 'EXT:direct_mail/Resources/Public/Icons/mail.gif',
         'type' => 'type',
         'useColumnsForDefaultValues' => 'from_email,from_name,replyto_email,replyto_name,organisation,priority,encoding,charset,sendOptions,type',
-        'dividers2tabs' => true,
         'languageField' => 'sys_language_uid'
-    ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid,type,plainParams,HTMLParams,subject,from_name,from_email,replyto_name,replyto_email,return_path,organisation,attachment,priority,encoding,charset,sendOptions,includeMedia,flowedFormat,issent,renderedsize,use_rdct,long_link_mode,authcode_fieldList'
     ],
     'columns' => [
         'sys_language_uid' => [

--- a/Configuration/TCA/sys_dmail_category.php
+++ b/Configuration/TCA/sys_dmail_category.php
@@ -17,9 +17,6 @@ return [
         ],
         'iconfile' => 'EXT:direct_mail/Resources/Public/Icons/icon_tx_directmail_category.gif',
     ],
-    'interface' => [
-        'showRecordFieldList' => 'hidden,category'
-    ],
     'columns' => [
         'sys_language_uid' => [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',

--- a/Configuration/TCA/sys_dmail_group.php
+++ b/Configuration/TCA/sys_dmail_group.php
@@ -11,9 +11,6 @@ return [
         'iconfile' => 'EXT:direct_mail/Resources/Public/Icons/mailgroup.gif',
         'type' => 'type',
     ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uidtype,title,description'
-    ],
     'columns' => [
         'sys_language_uid' => [
             'exclude' => 1,

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -52,6 +52,7 @@ if (TYPO3_MODE == 'BE') {
             'routeTarget' => DirectMailTeam\DirectMail\Module\Dmail::class . '::mainAction',
             'access' => 'group,user',
             'name' => 'DirectMailNavFrame_DirectMail',
+            'workspaces' => 'online',
             'icon' => 'EXT:direct_mail/Resources/Public/Images/module-directmail-directmail.svg',
             'labels' => [
                 'll_ref' => 'LLL:EXT:direct_mail/Resources/Private/Language/locallangDirectMail.xlf',
@@ -70,6 +71,7 @@ if (TYPO3_MODE == 'BE') {
             'routeTarget' => DirectMailTeam\DirectMail\Module\RecipientList::class . '::mainAction',
             'access' => 'group,user',
             'name' => 'DirectMailNavFrame_RecipientList',
+            'workspaces' => 'online',
             'icon' => 'EXT:direct_mail/Resources/Public/Images/module-directmail-recipient-list.svg',
             'labels' => [
                 'll_ref' => 'LLL:EXT:direct_mail/Resources/Private/Language/locallangRecipientList.xlf',
@@ -88,6 +90,7 @@ if (TYPO3_MODE == 'BE') {
             'routeTarget' => DirectMailTeam\DirectMail\Module\Statistics::class . '::mainAction',
             'access' => 'group,user',
             'name' => 'DirectMailNavFrame_Statistics',
+            'workspaces' => 'online',
             'icon'   => 'EXT:direct_mail/Resources/Public/Images/module-directmail-statistics.svg',
             'labels' => [
                 'll_ref' => 'LLL:EXT:direct_mail/Resources/Private/Language/locallangStatistics.xlf',
@@ -106,6 +109,7 @@ if (TYPO3_MODE == 'BE') {
             'routeTarget' => DirectMailTeam\DirectMail\Module\MailerEngine::class . '::mainAction',
             'access' => 'group,user',
             'name' => 'DirectMailNavFrame_MailerEngine',
+            'workspaces' => 'online',
             'icon'   => 'EXT:direct_mail/Resources/Public/Images/module-directmail-mailer-engine.svg',
             'labels' => [
                 'll_ref' => 'LLL:EXT:direct_mail/Resources/Private/Language/locallangMailerEngine.xlf',
@@ -124,6 +128,7 @@ if (TYPO3_MODE == 'BE') {
             'routeTarget' => DirectMailTeam\DirectMail\Module\Configuration::class . '::mainAction',
             'access' => 'group,user',
             'name' => 'DirectMailNavFrame_Configuration',
+            'workspaces' => 'online',
             'icon'   => 'EXT:direct_mail/Resources/Public/Images/module-directmail-configuration.svg',
             'labels' => [
                 'll_ref' => 'LLL:EXT:direct_mail/Resources/Private/Language/locallangConfiguration.xlf',


### PR DESCRIPTION
Since pages_language_overlay entries has been moved to table pages as new translated entries for its parent language,
those pages will no longer be shown in navigation frame for Newsletter pages.

TYPO3 version 9.5 and 10.4