### PR TITLE
[BUGFIX] Fix authcode validation, system marker substitution and target url if there is no recepient

### DIFF
--- a/Classes/Middleware/JumpurlController.php
+++ b/Classes/Middleware/JumpurlController.php
@@ -313,17 +313,12 @@ class JumpurlController implements MiddlewareInterface
     {
         $authCodeToMatch = GeneralUtility::stdAuthCode(
             $this->recipientRecord,
-            ($this->directMailRecord['authcode_fieldList'] ?? 'uid')
+            ($this->directMailRecord['authcode_fieldList'] ?: 'uid')
         );
 
-         if (!empty($submittedAuthCode) && $submittedAuthCode === $authCodeToMatch) {
-             // TODO: do we really need that much information?
+         if (!empty($submittedAuthCode) && $submittedAuthCode !== $authCodeToMatch) {
              throw new \Exception(
-                 'authCode verification failed.' .
-                 ' recipientUid = ' . $this->recipientRecord['uid'] .
-                 ' theTable = ' . $this->recipientTable .
-                 ' authcode_fieldList' . $this->directMailRecord['authcode_fieldList'] .
-                 ' AC = ' . $submittedAuthCode . ' AuthCode = ' . $authCodeToMatch,
+                 'authCode verification failed.',
                  1376899631
              );
          }

--- a/Classes/Middleware/JumpurlController.php
+++ b/Classes/Middleware/JumpurlController.php
@@ -92,12 +92,12 @@ class JumpurlController implements MiddlewareInterface
                 $urlId = $jumpurl;
                 $this->initDirectMailRecord($mailId);
                 $this->initRecipientRecord($submittedRecipient);
-                $targetUrl = $this->getTargetUrl($jumpurl);
+                $jumpurl = $this->getTargetUrl($jumpurl);
 
                 // try to build the ready-to-use target url
                 if (!empty($this->recipientRecord)) {
                     $this->validateAuthCode($submittedAuthCode);
-                    $jumpurl = $this->substituteMarkersFromTargetUrl($targetUrl);
+                    $jumpurl = $this->substituteMarkersFromTargetUrl($jumpurl);
 
                     $this->performFeUserAutoLogin();
                 }

--- a/Classes/Middleware/JumpurlController.php
+++ b/Classes/Middleware/JumpurlController.php
@@ -380,8 +380,8 @@ class JumpurlController implements MiddlewareInterface
      */
     protected function substituteSystemMarkersFromTargetUrl($targetUrl): string
     {
-        $mailId = $this->request->getAttribute('mid');
-        $submittedAuthCode = $this->request->getAttribute('aC');
+        $mailId = $this->request->getQueryParams()['mid'];
+        $submittedAuthCode = $this->request->getQueryParams()['aC'];
 
         // substitute system markers
         $markers = ['###SYS_TABLE_NAME###', '###SYS_MAIL_ID###', '###SYS_AUTHCODE###'];


### PR DESCRIPTION
There are three issues introduced by the rewrite of JumpurlController which are fixed by this pull request:

**1. Authcode validation was broken**
If `authCode_fieldList` is not set explicitly in the direct mail record, the default value provided from the database is `$this->directMailRecord['authcode_fieldList'] = ''`. However, `'' ?? 'uid'` evaluates to `''` which leads to the generation of a non-matching authcode. Using ternary operator resolves this aspect (cp. https://www.php.net/manual/en/types.comparisons.php)

At the same time, the system throws an exception if `$submittedAuthCode === $authCodeToMatch` as the operator was not changed to `!==`. Furthermore, the error message of the exception should not contain the correct authchode for security reasons (closely related to #231 in 6.0.2).

**2. System marker substitution doesn't work**
The system markers `###SYSTEM_AUTHCODE###` and `###SYSTEM_MAIL_ID###` are provided by request params `mid` and `aC, not by attributes of the request.

**3. Jumpurl is not replaced by target url if recipient can't be loaded**
If `$this->recipientRecord` is empty, the target url is only written to `$targetUrl`, written back to `$jumpurl`. This fix only restores the behaviour from 6.0.2 and resolves #227.

@kartolo @jokumer Any feedback is welcome =)