### PR TITLE
[BUGFIX] Fix exception message in case of incorrect authcode

### DIFF
--- a/Classes/Hooks/JumpurlController.php
+++ b/Classes/Hooks/JumpurlController.php
@@ -132,7 +132,7 @@ class JumpurlController
                                     $_POST['logintype'] = 'login';
                                 }
                             } else {
-                                throw new \Exception('authCode: Calculated authCode did not match the submitted authCode. varDump = '.var_dump($recipRow).' $recipientUid = '.$recipientUid.' theTable = '.$theTable.' authcode_fieldList'.$row['authcode_fieldList'].' AC = '. $aC .' AuthCode = '. $authCode, 1376899631);
+                                throw new \Exception('authCode: Calculated authCode did not match the submitted authCode.');
                             }
                         }
                     }


### PR DESCRIPTION
Fixes the exception message thrown in JumpurlController of v6.0.2 if an incorrect authcode is supplied. The original version outputs the correct authcode for an arbitrary user on the system in case debugging output is not configured in a secure way.

I suggest this is an issue that should be fixed for direct_mail v6.0.X and Typo3 v9.

The only thing this PR does is fix the exception message.

Resolves: #231

@kartolo, I am grateful for feedback =)