### PR TITLE
[BUGFIX]  Selecting translated page in Backend fails with errors

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -1079,20 +1079,13 @@ class DirectMailUtility
         }
 
         $pageRecord = BackendUtility::getRecord('pages', $pageUid);
-        // Fetch page title from pages_language_overlay
+        // Fetch page title from translated page
         if ($newRecord['sys_language_uid'] > 0) {
-            if (strpos(VersionNumberUtility::getNumericTypo3Version(), '9') === 0) {
-                $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages');
-                $queryBuilder
-                    ->select('title')
-                    ->from('pages')
-                    ->where($queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($pageUid, \PDO::PARAM_INT)));
-            } else {
-                $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages_language_overlay');
-                $queryBuilder->select('title')
-                    ->from('pages_language_overlay')
-                    ->where($queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pageUid, \PDO::PARAM_INT)));
-            }
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages');
+            $queryBuilder
+                ->select('title')
+                ->from('pages')
+                ->where($queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($pageUid, \PDO::PARAM_INT)));
 
             $pageRecordOverlay = $queryBuilder->andWhere(
                 $queryBuilder->expr()->eq(


### PR DESCRIPTION
Removed condition checking for Typo3 9 and removed old default behaviour to fetch title from
pages_language_overlay table - doesn't exist anymore. As the extension is not meant to be backward compatible to Typo3 9 and lower it is safe to remove the compatibility code.