### PR TITLE
[BUGFIX] delete icon should be shown on queued direct_mail

### DIFF
--- a/Classes/Module/MailerEngine.php
+++ b/Classes/Module/MailerEngine.php
@@ -455,7 +455,9 @@ class MailerEngine extends BaseScriptClass
         $icon = $this->iconFactory->getIcon('actions-edit-delete', Icon::SIZE_SMALL);
         $dmail = BackendUtility::getRecord('sys_dmail', $uid);
 
-        if (!empty($dmail['scheduled_begin'])) {
+        // show delete icon if newsletter hasn't been sent, or not yet finished sending
+        if (!($dmail['scheduled_begin']) ||
+            ($dmail['scheduled_begin'] && $dmail['scheduled_end'] === 0)) {
             /** @var UriBuilder $uriBuilder */
             $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
             $moduleUrl = $uriBuilder->buildUriFromRoute(


### PR DESCRIPTION
currently delete icon is shown on already sent direct_mail

Resolves: #244