### PR TITLE
[BUGFIX] Avoid exception if data is too long for url column in sys_dmail_maillog

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -135,7 +135,7 @@ CREATE TABLE sys_dmail_maillog (
   email varchar(255) DEFAULT '' NOT NULL,
   rtbl char(1) DEFAULT '' NOT NULL,
   tstamp int(11) unsigned DEFAULT '0' NOT NULL,
-  url tinyblob NULL,
+  url blob NULL,
   size int(11) unsigned DEFAULT '0' NOT NULL,
   parsetime int(11) unsigned DEFAULT '0' NOT NULL,
   response_type tinyint(4) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Change type from tinyblob to blob for url column in sys_dmail_maillog table to avoid exception if data is too long.
This happens if the url is very long (in my case from an online car configurator) and jumpurl is enabled.

resolves #297 