### PR TITLE
[BUGFIX] Fix empty $_SERVER['HTTP_HOST'] in CLI context

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -1449,6 +1449,12 @@ class DirectMailUtility
     {
         $cObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
         // Finding the domain to use
+        if (!$_SERVER['HTTP_HOST']) {
+            // In CLI / Scheduler context, $_SERVER['HTTP_HOST'] can be null
+            $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+            $site = $siteFinder->getSiteByPageId((int)$row['page']);
+            $_SERVER['HTTP_HOST'] = $site->getBase()->getHost();
+        }
         $result = [
             'baseUrl' => $cObj->typolink_URL([
                 'parameter' => 't3://page?uid=' . (int)$row['page'],


### PR DESCRIPTION
In CLI / Scheduler context, $_SERVER['HTTP_HOST'] can be null.
This leads to a malformed URI.

If you need to test this patch on a development machine with a different base URL, make sure to run the scheduler with the proper context, e.g. like this:

`TYPO3_CONTEXT=Development/PK ./typo3cms scheduler:run`

Resolves: #273