### PR TITLE
Resolve warnings due to undefined array keys

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -141,7 +141,7 @@ class DirectMailUtility
      * @param array $params Any default parameters (usually the ones from pageTSconfig)
      * @param bool $returnArray Return error or warning message as array instead of string
      *
-     * @return string Error or warning message during fetching the content
+     * @return array|string Error or warning message during fetching the content
      */
     public static function fetchUrlContentsForDirectMailRecord(array $row, array $params, $returnArray = false)
     {

--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -162,7 +162,7 @@ class DirectMailUtility
         // Compile the mail
         /* @var $htmlmail Dmailer */
         $htmlmail = GeneralUtility::makeInstance(Dmailer::class);
-        if ($params['enable_jump_url']) {
+        if ($params['enable_jump_url'] ?? false) {
             $htmlmail->jumperURL_prefix = $urlBase . $glue .
                 'mid=###SYS_MAIL_ID###' .
                 (intval($params['jumpurl_tracking_privacy']) ? '' : '&rid=###SYS_TABLE_NAME###_###USER_uid###') .
@@ -170,7 +170,7 @@ class DirectMailUtility
                 '&jumpurl=';
             $htmlmail->jumperURL_useId = 1;
         }
-        if ($params['enable_mailto_jump_url']) {
+        if ($params['enable_mailto_jump_url'] ?? false) {
             $htmlmail->jumperURL_useMailto = 1;
         }
 
@@ -392,10 +392,10 @@ class DirectMailUtility
 
         $characterSet = 'utf-8';
 
-        if ($settings['config.']['metaCharset']) {
+        if (!empty($settings['config.']['metaCharset'])) {
             $characterSet = $settings['config.']['metaCharset'];
         } 
-        elseif ($GLOBALS['TYPO3_CONF_VARS']['BE']['forceCharset']) {
+        elseif (!empty($GLOBALS['TYPO3_CONF_VARS']['BE']['forceCharset'])) {
             $characterSet = $GLOBALS['TYPO3_CONF_VARS']['BE']['forceCharset'];
         }
 

--- a/Classes/Dmailer.php
+++ b/Classes/Dmailer.php
@@ -179,14 +179,14 @@ class Dmailer implements LoggerAwareInterface
         $this->from_email = $row['from_email'];
         $this->from_name = ($row['from_name'] ? $this->getCharsetConverter()->conv($row['from_name'], $this->backendCharset, $this->charset) : '');
 
-        $this->replyto_email = ($row['replyto_email'] ? $row['replyto_email'] : '');
+        $this->replyto_email = $row['replyto_email'] ?? '';
         $this->replyto_name  = ($row['replyto_name'] ? $this->getCharsetConverter()->conv($row['replyto_name'], $this->backendCharset, $this->charset) : '');
 
         $this->organisation  = ($row['organisation'] ? $this->getCharsetConverter()->conv($row['organisation'], $this->backendCharset, $this->charset) : '');
 
         $this->priority      = DirectMailUtility::intInRangeWrapper((int)$row['priority'], 1, 5);
         $this->mailer        = 'TYPO3 Direct Mail module';
-        $this->authCode_fieldList = ($row['authcode_fieldList'] ? $row['authcode_fieldList'] : 'uid');
+        $this->authCode_fieldList = $row['authcode_fieldList'] ?? 'uid';
 
         $this->dmailer['sectionBoundary'] = '<!--DMAILER_SECTION_BOUNDARY';
         $this->dmailer['html_content']    = $this->theParts['html']['content'] ?? '';


### PR DESCRIPTION
* Core: Error handler (BE): PHP Warning: Undefined array key "metaCharset"
* Core: Error handler (BE): PHP Warning: Undefined array key "forceCharset"
* Core: Error handler (BE): PHP Warning: Undefined array key "enable_jump_url"
* Core: Error handler (BE): PHP Warning: Undefined array key "enable_mailto_jump_url"

With this Step 1 (fetching page) in Direct Mail module has no more warnings