### PR TITLE
[TASK] Fix simulate user group

### DIFF
--- a/Classes/Hooks/TypoScriptFrontendController.php
+++ b/Classes/Hooks/TypoScriptFrontendController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace DirectMailTeam\DirectMail\Hooks;
 
 /*
@@ -15,6 +16,7 @@ namespace DirectMailTeam\DirectMail\Hooks;
  */
 
 use DirectMailTeam\DirectMail\Utility\DmRegistryUtility;
+use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -25,29 +27,28 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class TypoScriptFrontendController
 {
-
     /**
      * If a backend user is logged in and
      * a frontend usergroup is specified in the GET parameters, use this
      * group to simulate access to an access protected page with content to be sent
-     *
-     * @param $parameters
-     * @param \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $typoScriptFrontendController
-     *
-     * @return void
      */
-    public function simulateUsergroup($parameters, \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $typoScriptFrontendController): void
+    public function simulateUsergroup($parameters, \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $typoScriptFrontendController)
     {
         $directMailFeGroup = (int)GeneralUtility::_GET('dmail_fe_group');
         $accessToken = (string)GeneralUtility::_GET('access_token');
         if ($directMailFeGroup > 0 && GeneralUtility::makeInstance(DmRegistryUtility::class)->validateAndRemoveAccessToken($accessToken)) {
-            if ($typoScriptFrontendController->fe_user->user) {
-                $typoScriptFrontendController->fe_user->user[$typoScriptFrontendController->usergroup_column] = $directMailFeGroup;
-            } 
-            else {
-                $typoScriptFrontendController->fe_user->user = [
-                    $typoScriptFrontendController->fe_user->usergroup_column => $directMailFeGroup
-                ];
+
+            /** @var UserAspect $userAspect */
+            $userAspect = $typoScriptFrontendController->getContext()->getAspect('frontend.user');
+
+            // we reset the content if required
+            if (!in_array($directMailFeGroup, $userAspect->getGroupIds(), true)) {
+
+                // code was refactor, using a different hook!
+                $typoScriptFrontendController->getContext()->setAspect(
+                    'frontend.user',
+                    new UserAspect($typoScriptFrontendController->fe_user, [$directMailFeGroup])
+                );
             }
         }
     }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,21 +6,21 @@ defined('TYPO3') || die();
 // https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ExtensionArchitecture/BestPractises/ConfigurationFiles.html
 (function () {
     // Register hook for simulating a user group
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['determineId-PreProcessing']['direct_mail'] = 'DirectMailTeam\\DirectMail\\Hooks\TypoScriptFrontendController->simulateUsergroup';
-    
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['hook_checkEnableFields']['direct_mail'] = 'DirectMailTeam\\DirectMail\\Hooks\\TypoScriptFrontendController->simulateUsergroup';
+
     // Get extension configuration so we can use it here:
     $extConf = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('direct_mail');
-    
+
     /**
      * Language of the cron task:
      */
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['direct_mail']['cron_language'] = $extConf['cron_language'] ? $extConf['cron_language'] : 'en';
-    
+
     /**
      * Number of messages sent per cycle of the cron task:
      */
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['direct_mail']['sendPerCycle'] = $extConf['sendPerCycle'] ? $extConf['sendPerCycle'] : 50;
-    
+
     /**
      * Default recipient field list:
      */


### PR DESCRIPTION
To fetch protected pages the mailer needs to simulate a FE user group. Since the implementation of FE user authentication has changed to user aspect in v11, we need to adjust the implementation. Furthermore, we need to use another hook that comes later in the TypoScriptFrontendController instance