### PR TITLE
[TASK] Make jumpurl work without submitted recipient

### DIFF
--- a/Classes/Middleware/JumpurlController.php
+++ b/Classes/Middleware/JumpurlController.php
@@ -88,7 +88,7 @@ class JumpurlController implements MiddlewareInterface
 
         if ($this->shouldProcess()) {
             $mailId = (int)$this->request->getQueryParams()['mid'];
-            $submittedRecipient = $this->request->getQueryParams()['rid'];
+            $submittedRecipient = (string)$this->request->getQueryParams()['rid'];
             $submittedAuthCode  = $this->request->getQueryParams()['aC'];
             $jumpurl = $this->request->getQueryParams()['jumpurl'];
 


### PR DESCRIPTION
If jumpurl_tracking_privacy is active, jumpurls are generated without the rid parameter which contains the table and uid of the recipient. Therefore, the rid parameter must not be mandatory.