### PR TITLE
[BUGFIX] Use correct namespace for PDO

### DIFF
--- a/Classes/Repository/FeUsersRepository.php
+++ b/Classes/Repository/FeUsersRepository.php
@@ -45,7 +45,7 @@ class FeUsersRepository extends MainRepository {
             $queryBuilder = $this->getQueryBuilder($this->table);
             $queryBuilder->select('*')->from($this->table);
             $queryBuilder->where(
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, PDO::PARAM_INT)),
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, \PDO::PARAM_INT)),
                 $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0))
             );
 


### PR DESCRIPTION
Since PDO is in the root namespace, its usage must be prefixed with a backslash.