### PR TITLE
[BUGFIX] Jumpurl: Don't process if mail ID is not numeric

### DIFF
--- a/Classes/Middleware/JumpurlController.php
+++ b/Classes/Middleware/JumpurlController.php
@@ -164,7 +164,7 @@ class JumpurlController implements MiddlewareInterface
     protected function shouldProcess(): bool
     {
         $mid = $this->request->getQueryParams()['mid'] ?? null;
-        return ($mid !== null);
+        return ($mid && MathUtility::canBeInterpretedAsInteger($mid));
     }
 
     /**


### PR DESCRIPTION
If jumpurl is used and a test mail (step 4) is sent, there is nether a mail id (mid) nor an authcode (aC) in the jumpurls:

https://foobar.com/newsletter/?mid=###SYS_MAIL_ID###&aC=###SYS_AUTHCODE###&jumpurl=7

In this case, jumpurl processing should be bypassed to avoid further errors. Furthermore, it makes no sense to log links clicked in test sendings.