### PR TITLE
BUGFIX, getFEgroupSubgroups(), deprecated funktions

### DIFF
--- a/Classes/Module/RecipientListController.php
+++ b/Classes/Module/RecipientListController.php
@@ -8,13 +8,10 @@ use DirectMailTeam\DirectMail\DmQueryGenerator;
 use DirectMailTeam\DirectMail\Utility\DmCsvUtility;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\View\StandaloneView;
 use DirectMailTeam\DirectMail\DirectMailUtility;
 use DirectMailTeam\DirectMail\Repository\SysDmailGroupRepository;
 use DirectMailTeam\DirectMail\Repository\FeUsersRepository;
@@ -29,54 +26,54 @@ class RecipientListController extends MainController
      * @var string
      */
     protected $moduleName = '';
-    
+
     protected int $group_uid = 0;
     protected string $lCmd = '';
     protected string $csv = '';
     protected array $set = [];
     protected string $fieldList = 'uid,name,first_name,middle_name,last_name,title,email,phone,www,address,company,city,zip,country,fax,module_sys_dmail_category,module_sys_dmail_html';
-    
+
     protected $MOD_SETTINGS;
-    
-    protected int $uid = 0; 
+
+    protected int $uid = 0;
     protected string $table = '';
     protected array $indata = [];
-    
+
     protected $requestHostOnly = '';
     protected $requestUri = '';
     protected $httpReferer = '';
     protected $allowedTables = ['tt_address', 'fe_users'];
-    
+
     private bool $submit = false;
-    
+
     protected function initRecipientList(ServerRequestInterface $request): void {
         $queryParams = $request->getQueryParams();
         $parsedBody = $request->getParsedBody();
-        
+
         $normalizedParams = $request->getAttribute('normalizedParams');
         $this->requestHostOnly = $normalizedParams->getRequestHostOnly();
         $this->requestUri = $normalizedParams->getRequestUri();
         $this->httpReferer = $request->getServerParams()['HTTP_REFERER'];
-        
+
         $this->group_uid = (int)($parsedBody['group_uid'] ?? $queryParams['group_uid'] ?? 0);
         $this->lCmd = $parsedBody['lCmd'] ?? $queryParams['lCmd'] ?? '';
         $this->csv = $parsedBody['csv'] ?? $queryParams['csv'] ?? '';
         $this->set = is_array($parsedBody['csv'] ?? '') ? $parsedBody['csv'] : (is_array($queryParams['csv'] ?? '') ? $queryParams['csv'] : []);
-        
+
         $this->uid = (int)($parsedBody['uid'] ?? $queryParams['uid'] ?? 0);
         $this->table = (string)($parsedBody['table'] ?? $queryParams['table'] ?? '');
         $this->indata = $parsedBody['indata'] ?? $queryParams['indata'] ?? [];
         $this->submit = (bool)($parsedBody['submit'] ?? $queryParams['submit'] ?? false);
     }
-    
+
     public function indexAction(ServerRequestInterface $request) : ResponseInterface
     {
         $this->view = $this->configureTemplatePaths('RecipientList');
-        
+
         $this->init($request);
         $this->initRecipientList($request);
         $this->getLanguageService()->includeLLFile('EXT:direct_mail/Resources/Private/Language/locallang_csh_sysdmail.xlf');
-        
+
         if (($this->id && $this->access) || ($this->isAdmin() && !$this->id)) {
             $module = $this->getModulName();
             $this->moduleName = (string)($request->getQueryParams()['currentModule'] ?? $request->getParsedBody()['currentModule'] ?? 'DirectMailNavFrame_RecipientList');
@@ -115,14 +112,14 @@ class RecipientListController extends MainController
             $message = $this->createFlashMessage('If no access or if ID == zero', 'No Access', 1, false);
             $this->messageQueue->addMessage($message);
         }
-    
+
         /**
          * Render template and return html content
          */
         $this->moduleTemplate->setContent($this->view->render());
         return new HtmlResponse($this->moduleTemplate->renderContent());
     }
-    
+
     /**
      * Show the module content
      *
@@ -155,10 +152,10 @@ class RecipientListController extends MainController
                 $theOutput = '';
                 $type = 4;
         }
-        
+
         return ['data' => $data, 'content' => $theOutput, 'type' => $type];
     }
-    
+
     /**
      * Shows the existing recipient lists and shows link to create a new one or import a list
      *
@@ -170,14 +167,14 @@ class RecipientListController extends MainController
         $data = [
             'rows' => []
         ];
-        
+
         $rows = GeneralUtility::makeInstance(SysDmailGroupRepository::class)->selectSysDmailGroupByPid($this->id, trim($GLOBALS['TCA']['sys_dmail_group']['ctrl']['default_sortby']));
-        
+
         foreach($rows as $row) {
             $result = $this->cmd_compileMailGroup(intval($row['uid']));
             $count = 0;
             $idLists = $result['queryInfo']['id_lists'];
-            
+
             if (is_array($idLists['tt_address'] ?? false)) {
                 $count += count($idLists['tt_address']);
             }
@@ -199,7 +196,7 @@ class RecipientListController extends MainController
                 'count'       => $count
             ];
         }
-        
+
         $data['editOnClickLink'] = DirectMailUtility::getEditOnClickLink([
             'edit' => [
                 'sys_dmail_group' => [
@@ -208,9 +205,9 @@ class RecipientListController extends MainController
             ],
             'returnUrl' => $this->requestUri,
         ]);
-        
+
         $data['sysDmailGroupIcon'] = $this->iconFactory->getIconForRecord('sys_dmail_group', [], Icon::SIZE_SMALL);
-            
+
         // Import
         $data['moduleUrl'] = $this->buildUriFromRoute(
             $this->moduleName,
@@ -221,7 +218,7 @@ class RecipientListController extends MainController
         );
         return $data;
     }
-    
+
     /**
      * Put all recipients uid from all table into an array
      *
@@ -291,7 +288,7 @@ class RecipientListController extends MainController
                         if ($mailGroup['csv'] == 1) {
                             $dmCsvUtility = GeneralUtility::makeInstance(DmCsvUtility::class);
                             $recipients = $dmCsvUtility->rearrangeCsvValues($dmCsvUtility->getCsvValues($mailGroup['list']), $this->fieldList);
-                        } 
+                        }
                         else {
                             $recipients = DirectMailUtility::rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroup['list'])));
                         }
@@ -314,10 +311,10 @@ class RecipientListController extends MainController
                         $table = '';
                         if ($whichTables&1) {
                             $table = 'tt_address';
-                        } 
+                        }
                         elseif ($whichTables&2) {
                             $table = 'fe_users';
-                        } 
+                        }
                         elseif ($this->userTable && ($whichTables&4)) {
                             $table = $this->userTable;
                         }
@@ -336,7 +333,7 @@ class RecipientListController extends MainController
                                 $idLists = array_merge_recursive($idLists, $collect['queryInfo']['id_lists']);
                             }
                         }
-                        
+
                         // Make unique entries
                         if (is_array($idLists['tt_address'] ?? null)) {
                             $idLists['tt_address'] = array_unique($idLists['tt_address']);
@@ -361,7 +358,7 @@ class RecipientListController extends MainController
          */
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['direct_mail']['mod3']['cmd_compileMailGroup'] ?? false)) {
             $hookObjectsArr = [];
-            
+
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['direct_mail']['mod3']['cmd_compileMailGroup'] as $classRef) {
                 $hookObjectsArr[] = GeneralUtility::makeInstance($classRef);
             }
@@ -370,16 +367,16 @@ class RecipientListController extends MainController
                     $temporaryList = $hookObj->cmd_compileMailGroup_postProcess($idLists, $this, $mailGroup);
                 }
             }
-            
+
             unset($idLists);
             $idLists = $temporaryList;
         }
-        
+
         return [
             'queryInfo' => ['id_lists' => $idLists]
         ];
     }
-    
+
     /**
      * Shows edit link
      *
@@ -402,10 +399,10 @@ class RecipientListController extends MainController
                 'returnUrl' => $this->requestUri,
             ]);
         }
-        
+
         return $editLinkConfig;
     }
-    
+
     /**
      * Shows link to show the recipient infos
      *
@@ -428,7 +425,7 @@ class RecipientListController extends MainController
         );
         return '<a href="' . $moduleUrl . '">' . $str . '</a>';
     }
-    
+
     /**
      * Display infos of the mail group
      *
@@ -456,7 +453,7 @@ class RecipientListController extends MainController
 
         $group = BackendUtility::getRecord('sys_dmail_group', $this->group_uid);
         $group = is_array($group) ? $group : [];
-        
+
         $data = [
             'group_id' => $this->group_uid,
             'group_icon' => $this->iconFactory->getIconForRecord('sys_dmail_group', $group, Icon::SIZE_SMALL),
@@ -473,7 +470,7 @@ class RecipientListController extends MainController
             $dmCsvUtility = GeneralUtility::makeInstance(DmCsvUtility::class);
             if ($csvValue == 'PLAINLIST') {
                 $dmCsvUtility->downloadCSV($idLists['PLAINLIST']);
-            } 
+            }
             elseif (GeneralUtility::inList('tt_address,fe_users,' . $this->userTable, $csvValue)) {
                 if($this->getBackendUser()->check('tables_select', $csvValue)) {
                     $fields = $csvValue == 'fe_users' ? str_replace('phone', 'telephone', $this->fieldList) : $this->fieldList;
@@ -481,12 +478,12 @@ class RecipientListController extends MainController
 
                     $rows = GeneralUtility::makeInstance(TempRepository::class)->fetchRecordsListValues($idLists[$csvValue], $csvValue, $fields);
                     $dmCsvUtility->downloadCSV($rows);
-                } 
+                }
                 else {
                     $message = $this->createFlashMessage(
-                        '', 
-                        $this->getLanguageService()->getLL('mailgroup_table_disallowed_csv'), 
-                        2, 
+                        '',
+                        $this->getLanguageService()->getLL('mailgroup_table_disallowed_csv'),
+                        2,
                         false
                     );
                     $this->messageQueue->addMessage($message);
@@ -538,7 +535,7 @@ class RecipientListController extends MainController
                         'mailgroup_download_link' => GeneralUtility::linkThisScript(['csv'=>'tt_address'])
                     ];
                 }
-                
+
                 if (is_array($idLists['fe_users'] ?? false) && count($idLists['fe_users'])) {
                     $data['tables'][] = [
                         'title_table' => 'mailgroup_table_fe_users',
@@ -547,7 +544,7 @@ class RecipientListController extends MainController
                         'mailgroup_download_link' => GeneralUtility::linkThisScript(['csv'=>'fe_users'])
                     ];
                 }
-                        
+
                 if (is_array($idLists['PLAINLIST'] ?? false) && count($idLists['PLAINLIST'])) {
                     $data['tables'][] = [
                         'title_table' => 'mailgroup_plain_list',
@@ -556,7 +553,7 @@ class RecipientListController extends MainController
                         'mailgroup_download_link' => GeneralUtility::linkThisScript(['csv'=>'PLAINLIST'])
                     ];
                 }
-                
+
                 if (!in_array($this->userTable, ['tt_address', 'fe_users', 'PLAINLIST']) && is_array($idLists[$this->userTable] ?? false) && count($idLists[$this->userTable])) {
                     $data['tables'][] = [
                         'title_table' => 'mailgroup_table_custom',
@@ -575,7 +572,7 @@ class RecipientListController extends MainController
 
         return $data;
     }
-    
+
     /**
      * Update recipient list record with a special query
      *
@@ -594,33 +591,33 @@ class RecipientListController extends MainController
         $table = '';
         if ($whichTables&1) {
             $table = 'tt_address';
-        } 
+        }
         elseif ($whichTables&2) {
             $table = 'fe_users';
-        } 
+        }
         elseif ($this->userTable && ($whichTables&4)) {
             $table = $this->userTable;
         }
-        
+
         $this->MOD_SETTINGS['queryTable'] = $queryTable ? $queryTable : $table;
         $this->MOD_SETTINGS['queryConfig'] = $queryConfig ? serialize($queryConfig) : $mailGroup['query'];
         $this->MOD_SETTINGS['search_query_smallparts'] = 1;
-        
+
         $this->MOD_SETTINGS['search_query_makeQuery'] = 'all';
         $this->MOD_SETTINGS['search'] = 'query';
 
         if ($this->MOD_SETTINGS['queryTable'] != $table) {
             $this->MOD_SETTINGS['queryConfig'] = '';
         }
-        
+
         if ($this->MOD_SETTINGS['queryTable'] != $table || $this->MOD_SETTINGS['queryConfig'] != $mailGroup['query']) {
             $whichTables = 0;
             if ($this->MOD_SETTINGS['queryTable'] == 'tt_address') {
                 $whichTables = 1;
-            } 
+            }
             elseif ($this->MOD_SETTINGS['queryTable'] == 'fe_users') {
                 $whichTables = 2;
-            } 
+            }
             elseif ($this->MOD_SETTINGS['queryTable'] == $this->userTable) {
                 $whichTables = 4;
             }
@@ -628,7 +625,7 @@ class RecipientListController extends MainController
                 'whichtables' => intval($whichTables),
                 'query' => $this->MOD_SETTINGS['queryConfig']
             ];
-            
+
             $connection = $this->getConnection('sys_dmail_group');
             $connection->update(
                 'sys_dmail_group', // table
@@ -639,7 +636,7 @@ class RecipientListController extends MainController
         }
         return $mailGroup;
     }
-    
+
     /**
      * Show HTML form to make special query
      *
@@ -658,10 +655,10 @@ class RecipientListController extends MainController
         $this->pageRenderer->loadRequireJsModule('TYPO3/CMS/Lowlevel/QueryGenerator');
         $this->pageRenderer->loadRequireJsModule('TYPO3/CMS/Backend/DateTimePicker');
         [$html, $query] = $queryGenerator->queryMakerDM();
-        
+
         return ['selectTables' => $html, 'query' => $query];
     }
-    
+
     /**
      * Shows user's info and categories
      *
@@ -677,7 +674,7 @@ class RecipientListController extends MainController
                 $this->indata['html'] = 0;
             }
         }
-        
+
         switch ($this->table) {
             case 'tt_address':
                 // see fe_users
@@ -698,7 +695,7 @@ class RecipientListController extends MainController
                         }
                     }
                     $data[$this->table][$this->uid]['module_sys_dmail_html'] = $this->indata['html'] ? 1 : 0;
-                    
+
                     /* @var $dataHandler \TYPO3\CMS\Core\DataHandling\DataHandler*/
                     $dataHandler = $this->getDataHandler();
                     $dataHandler->stripslashes_values = 0;
@@ -721,11 +718,11 @@ class RecipientListController extends MainController
             default:
                 // do nothing
         }
-        
+
         $theOutput = '';
-        
+
         $row = $rows[0] ?? [];
-        
+
         if (is_array($row) && count($row)) {
             $mmTable = $GLOBALS['TCA'][$this->table]['columns']['module_sys_dmail_category']['config']['MM'];
             $resCat = GeneralUtility::makeInstance(TempRepository::class)->getDisplayUserInfo((string)$mmTable, (int)$row['uid']);
@@ -735,9 +732,9 @@ class RecipientListController extends MainController
                     $categoriesArray[] = $rowCat['uid_foreign'];
                 }
             }
-            
+
             $categories = implode(',', $categoriesArray);
-            
+
             $editOnClickLink = DirectMailUtility::getEditOnClickLink([
                 'edit' => [
                     $this->table => [
@@ -761,7 +758,7 @@ class RecipientListController extends MainController
                 'html' => $row['module_sys_dmail_html'] ? true : false
             ];
             $this->categories = GeneralUtility::makeInstance(TempRepository::class)->makeCategories($this->table, $row, $this->sys_language_uid);
-                    
+
             reset($this->categories);
             foreach ($this->categories as $pKey => $pVal) {
                 $dataout['categories'][] = [
@@ -773,12 +770,12 @@ class RecipientListController extends MainController
         }
         return $dataout;
     }
-    
+
     public function getRequestHostOnly(): string
     {
         return $this->requestHostOnly;
     }
-    
+
     public function getHttpReferer(): string
     {
         return $this->httpReferer;


### PR DESCRIPTION
as static list, more than one fe-groups could be selected, e.g. group1, group2, all the sub-fe-groups of group1 and group2 should be fetched als well.

TempRepository.php has LF as  line break type.