### PR TITLE
[BUGFIX] Space-separated recipient list: Check for null before using preg_split

### DIFF
--- a/Classes/Module/DmailController.php
+++ b/Classes/Module/DmailController.php
@@ -1616,7 +1616,8 @@ class DmailController extends MainController
                             $recipients = $dmCsvUtility->rearrangeCsvValues($dmCsvUtility->getCsvValues($mailGroup['list']), $this->fieldList);
                         }
                         else {
-                            $recipients = $this->rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroup['list'])));
+                            $mailGroupList = $mailGroup['list'];
+                            $recipients = $mailGroupList ? DirectMailUtility::rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroupList))) : [];
                         }
                         $idLists['PLAINLIST'] = $this->cleanPlainList($recipients);
                         break;

--- a/Classes/Module/DmailController.php
+++ b/Classes/Module/DmailController.php
@@ -1617,7 +1617,7 @@ class DmailController extends MainController
                         }
                         else {
                             $mailGroupList = $mailGroup['list'];
-                            $recipients = $mailGroupList ? DirectMailUtility::rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroupList))) : [];
+                            $recipients = $mailGroupList ? $this->rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroupList))) : [];
                         }
                         $idLists['PLAINLIST'] = $this->cleanPlainList($recipients);
                         break;

--- a/Classes/Module/RecipientListController.php
+++ b/Classes/Module/RecipientListController.php
@@ -290,7 +290,8 @@ class RecipientListController extends MainController
                             $recipients = $dmCsvUtility->rearrangeCsvValues($dmCsvUtility->getCsvValues($mailGroup['list']), $this->fieldList);
                         }
                         else {
-                            $recipients = $this->rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroup['list'])));
+                            $mailGroupList = $mailGroup['list'];
+                            $recipients = $mailGroupList ? DirectMailUtility::rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroupList))) : [];
                         }
                         $idLists['PLAINLIST'] = $this->cleanPlainList($recipients);
                         break;

--- a/Classes/Module/RecipientListController.php
+++ b/Classes/Module/RecipientListController.php
@@ -291,7 +291,7 @@ class RecipientListController extends MainController
                         }
                         else {
                             $mailGroupList = $mailGroup['list'];
-                            $recipients = $mailGroupList ? DirectMailUtility::rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroupList))) : [];
+                            $recipients = $mailGroupList ? $this->rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroupList))) : [];
                         }
                         $idLists['PLAINLIST'] = $this->cleanPlainList($recipients);
                         break;


### PR DESCRIPTION
In a normal, space-separated recipient list, the addresses are stored in a MEDIUMBLOB field. This field is nullable by default, therefore if no list has been entered, the field will have a NULL value. This breaks displaying or using recipient lists, becase preg_split cannot be applied on a NULL value. This is prevented by adding a check before using preg_split.