### PR TITLE
[BUGFIX] Store full rid in maillog (resolves #379)

### DIFF
--- a/Classes/Middleware/JumpurlController.php
+++ b/Classes/Middleware/JumpurlController.php
@@ -134,7 +134,7 @@ class JumpurlController implements MiddlewareInterface
                     'response_type' => $this->responseType,
                     'url_id'        => (int)$urlId,
                     'rtbl'          => mb_substr($this->recipientTable, 0, 1),
-                    'rid'           => (int)($recipientUid ?? $this->recipientRecord['uid']),
+                    'rid'           => $recipientUid ?? (int) $this->recipientRecord['uid'],
                 ];
                 $sysDmailMaillogRepository = GeneralUtility::makeInstance(SysDmailMaillogRepository::class);
                 if ($sysDmailMaillogRepository->hasRecentLog($mailLogParams) === false) {

--- a/Classes/Middleware/JumpurlController.php
+++ b/Classes/Middleware/JumpurlController.php
@@ -123,7 +123,7 @@ class JumpurlController implements MiddlewareInterface
                 }
 
                 // to count the dmailerping correctly, we need something unique
-                $recipientUid = $submittedAuthCode;
+                $authCode = preg_replace("/[^a-zA-Z0-9]/", "", $submittedAuthCode);
             }
 
             if ($this->responseType !== 0) {
@@ -134,7 +134,7 @@ class JumpurlController implements MiddlewareInterface
                     'response_type' => $this->responseType,
                     'url_id'        => (int)$urlId,
                     'rtbl'          => mb_substr($this->recipientTable, 0, 1),
-                    'rid'           => $recipientUid ?? (int) $this->recipientRecord['uid'],
+                    'rid'           => $authCode ?? (int) $this->recipientRecord['uid'],
                 ];
                 $sysDmailMaillogRepository = GeneralUtility::makeInstance(SysDmailMaillogRepository::class);
                 if ($sysDmailMaillogRepository->hasRecentLog($mailLogParams) === false) {

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -126,7 +126,7 @@ CREATE TABLE sys_dmail_group_mm (
 CREATE TABLE sys_dmail_maillog (
   uid int(11) unsigned NOT NULL auto_increment,
   mid int(11) unsigned DEFAULT '0' NOT NULL,
-  rid varchar(11) DEFAULT '0' NOT NULL,
+  rid varchar(40) DEFAULT '0' NOT NULL,
   email varchar(255) DEFAULT '' NOT NULL,
   rtbl char(1) DEFAULT '' NOT NULL,
   tstamp int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
**Problem:**

Since the update to the 11 version, we see that the open rate according to the statistics module is significantly lower than for newsletters sent with DirectMail 6.0.2 (see https://github.com/kartolo/direct_mail/issues/379). My guess is that the rid field in the log is not filled properly. 

**Cause:**
First I checked how the number of opened mails is calculated in the first place. This is done here: 
https://github.com/SSFGizmo/direct_mail/blob/c5c796a23667d4bb152a32426a6ecaf0af6fa058/Classes/Repository/SysDmailMaillogRepository.php#L131

The groupBy rid is important to prevent multiple counts. But this also means that the rid must be unique per recipient. And I think that there is currently a problem. 

For the calculation of the open rate, the count of the tracking pixel is crucial. This is what happens here: 
https://github.com/SSFGizmo/direct_mail/blob/c5c796a23667d4bb152a32426a6ecaf0af6fa058/Classes/Middleware/JumpurlController.php#L126

I think the cause of the problem is here: the AuthCode is cast to an integer. This doesn't always seem to produce unique IDs. 
https://github.com/SSFGizmo/direct_mail/blob/c5c796a23667d4bb152a32426a6ecaf0af6fa058/Classes/Middleware/JumpurlController.php#L137

For example, if you have the URL https://example.org/newsletter-vorlage?mid=4005&rid=t_688612&aC=d608890ffc09d2a10630433c6cb1020892cf4363&jumpurl=https://example.org/typo3conf/ext/direct_mail/Resources/Public/Icons/dmailerping.gif, then the value "0" is stored in the sys_dmail_maillog.rid field after casting. But the expected value would have been the full AuthCode (d608890ffc09d2a10630433c6cb1020892cf4363). 

If this inaccuracy occurs with multiple recipients, then the open rate can no longer be calculated correctly. With DirectMail 6.0.2 there was no casting yet, but the AuthCode was shorter then. The casting came with the following commit:
https://github.com/kartolo/direct_mail/commit/6dd0a6571b2ea6d061b36cd26964f9627eb78e61

**Possible solution:**
According to ext_tables.sql, the rid field has the definition varchar(11)
https://github.com/SSFGizmo/direct_mail/blob/c5c796a23667d4bb152a32426a6ecaf0af6fa058/ext_tables.sql#L129

Thus, there is no need to cast to Int. However, the AuthCode would be significantly too long for the field. The AuthCode is created with GeneralUtility::hmac(). It returns a 40 character string according to the documentation:
https://github.com/TYPO3/typo3/blob/ebb5d3c318def3aa68ebeca7ec32e8616fabdcc7/typo3/sysext/core/Classes/Utility/GeneralUtility.php#L580

So if we change rid to varchar(40) and instead of $recipientUid just cast $this->recipientRecord['uid'] to int, the value in the field rid should be correct. I also changed the variable name and added simple sanitization. 

**Disadvantages of the solution:**

- Field sys_dmail_maillog.rid becomes longer (varchar 40 instead of 11)
- General problem: 
  - field name rid is meant for recipient ID, but can also be authCode
  - Might be better if a entry in sys_dmail_maillog is only created when the authCode is valid (for dmailerping.gif)

