### PR TITLE
[BUGFIX] Prevent undefined recipientRecord['uid'] when sending newsletter with type "normal list"

### DIFF
--- a/Classes/Middleware/JumpurlController.php
+++ b/Classes/Middleware/JumpurlController.php
@@ -94,6 +94,8 @@ class JumpurlController implements MiddlewareInterface
                 $urlId = $jumpurl;
                 $this->initDirectMailRecord($mailId);
                 $this->initRecipientRecord($submittedRecipient);
+                $rid = $this->recipientRecord['uid'] ?? 0;
+
                 $jumpurl = $this->getTargetUrl((int)$jumpurl);
 
                 // try to build the ready-to-use target url
@@ -123,7 +125,7 @@ class JumpurlController implements MiddlewareInterface
                 }
 
                 // to count the dmailerping correctly, we need something unique
-                $authCode = preg_replace("/[^a-zA-Z0-9]/", "", $submittedAuthCode);
+                $submittedAuthCode = preg_replace("/[^a-zA-Z0-9]/", "", $submittedAuthCode);
             }
 
             if ($this->responseType !== 0) {
@@ -134,7 +136,7 @@ class JumpurlController implements MiddlewareInterface
                     'response_type' => $this->responseType,
                     'url_id'        => (int)$urlId,
                     'rtbl'          => mb_substr($this->recipientTable, 0, 1),
-                    'rid'           => $authCode ?? (int) $this->recipientRecord['uid'],
+                    'rid'           => $rid ?? $submittedAuthCode,
                 ];
                 $sysDmailMaillogRepository = GeneralUtility::makeInstance(SysDmailMaillogRepository::class);
                 if ($sysDmailMaillogRepository->hasRecentLog($mailLogParams) === false) {


### PR DESCRIPTION
Fixes:
PHP Warning: Undefined array key "uid" in /var/www/html/web/typo3conf/ext/direct_mail/Classes/Middleware/JumpurlController.php line 137

$this->recipientRecord is an empty array when a newsletter gets sent with recipient group of type normal list. Tested with PHP 8.1