### PR TITLE
[BUGFIX] Cast replace parameter to string for str_replace()

### DIFF
--- a/Classes/Middleware/JumpurlController.php
+++ b/Classes/Middleware/JumpurlController.php
@@ -261,7 +261,7 @@ class JumpurlController implements MiddlewareInterface
             if (isset($this->recipientRecord[$substField])) {
                 $processedTargetUrl = str_replace(
                     '###USER_' . $substField . '###',
-                    $this->recipientRecord[$substField],
+                    (string) $this->recipientRecord[$substField],
                     $processedTargetUrl
                 );
             }


### PR DESCRIPTION
$this->recipientRecord['uid'] is of type int, but the replace parameter of str_replace needs to be string or string[]
Tested with PHP 8.1