### PR TITLE
Update Index.rst (jumpurls)

### DIFF
--- a/Documentation/Configuration/EnablingClickStatistics/Index.rst
+++ b/Documentation/Configuration/EnablingClickStatistics/Index.rst
@@ -40,8 +40,11 @@ address of a script. Such attribute in HTML content of email messages
 may be disabled by SPAM filtering software.
 
 If the :ref:`jumpurl_tracking_privacy <pageTsconfig_jumpurl_tracking_privacy>` is enabled in the configuration, then you might
-want to use ``&no_jumpurl=1`` for link, which should not be replaced by
-a jump URL.
+want to use ``no_jumpurl=1`` for link, which should not be replaced by a jump URL.
+
+.. code-block:: html
+
+   <a no_jumpurl=1 href="https://www.domain.tld/unsubscribe.html?u=###USER_uid###&t=###SYS_TABLE_NAME###&a=###SYS_AUTHCODE###">unsubscribe</a> 
 
 
 Adding third party tracking images


### PR DESCRIPTION
Clearify documentation for preventing generation of jumpurls to fit new version of direct mail. Added an example (unsubscribe link).  In the old documentation it looked like you had to set a link parameter.