### PR TITLE
Fix PHP 8.1 deprecation exceptions

### DIFF
--- a/Classes/Dmailer.php
+++ b/Classes/Dmailer.php
@@ -354,7 +354,7 @@ class Dmailer implements LoggerAwareInterface
     public function sendAdvanced(array $recipientRow, string $tableNameChar): int
     {
         $returnCode = 0;
-        $recipientRow = array_map('htmlspecialchars', $recipientRow);
+        $recipientRow = array_map(function($a) { return @htmlspecialchars($a); }, $recipientRow);
 
         // Workaround for strict checking of email addresses in TYPO3
         // (trailing newline = invalid address)

--- a/Classes/Module/DmailController.php
+++ b/Classes/Module/DmailController.php
@@ -1418,6 +1418,7 @@ class DmailController extends MainController
             $this->messageQueue->addMessage($message);
         }
 
+        // @todo Replace deprecated strftime for php 9. Suppress warning for php 8.1 and later
         return [
             'id' => $this->id,
             'sys_dmail_uid' => $this->sys_dmail_uid,
@@ -1425,8 +1426,8 @@ class DmailController extends MainController
             'hookSelectDisabled' => $hookSelectDisabled, // put content from hook
             'lastGroup' => $lastGroup,
             'opt' => $opt,
-            'send_mail_datetime_hr' => strftime('%H:%M %d-%m-%Y', time()),
-            'send_mail_datetime' => strftime('%H:%M %d-%m-%Y', time()),
+            'send_mail_datetime_hr' => @strftime('%H:%M %d-%m-%Y', time()),
+            'send_mail_datetime' => @strftime('%H:%M %d-%m-%Y', time()),
         ];
     }
 


### PR DESCRIPTION
Fix two PHP 8.1 related exceptions:

1. When preparing the newsletter on "Step 5":
```
(1/1) #1476107295 TYPO3\CMS\Core\Error\Exception

PHP Runtime Deprecation Notice: Function strftime() is deprecated in /app/html/typo3conf/ext/direct_mail/Classes/Module/DmailController.php line 1428
```

See: https://php.watch/versions/8.1/strftime-gmstrftime-deprecated

For now, we just supress the warning, this has to be rewritten when you want to be compatible with PHP 9.x later on.

2. When running the queue processor:
```
Die Ausführung von Task "Direct Mail: Mailing Queue (direct_mail)" ist fehlgeschlagen mit folgender Meldung: PHP Runtime Deprecation Notice: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /app/html/typo3conf/ext/direct_mail/Classes/Dmailer.php line 357
```