### PR TITLE
[BUGFIX] Prevent type error in FetchUtility::getResponse()

### DIFF
--- a/Classes/Utility/FetchUtility.php
+++ b/Classes/Utility/FetchUtility.php
@@ -38,7 +38,7 @@ class FetchUtility
 
     public function getResponse(string $url): Response
     {
-        $context = null;
+        $context = [];
         $applicationContext = Environment::getContext();
         if ($applicationContext->isDevelopment()) {
             $context = ['verify' => Typo3ConfVarsUtility::getDMConfigSSLVerify()];


### PR DESCRIPTION
Prevents the type error: `TYPO3\CMS\Core\Http\RequestFactory::request(): Argument #3 ($options) must be of type array, null given, called in /var/www/html/vendor/directmailteam/direct-mail/Classes/Utility/FetchUtility.php on line 47`