### PR TITLE
fix: Creation of dynamic property MailFromDraft::$dmailUid is deprecated

### DIFF
--- a/Classes/Scheduler/MailFromDraft.php
+++ b/Classes/Scheduler/MailFromDraft.php
@@ -37,6 +37,8 @@ class MailFromDraft extends AbstractTask
 {
     public int $draftUid = 0;
 
+    protected int $dmailUid = 0;
+
     protected array $hookObjects = [];
 
     /**


### PR DESCRIPTION
Fixes #490