### PR TITLE
[BUGFIX] Drop removal of mailto for email links in plaintext

### DIFF
--- a/Classes/Plugin/DirectMail.php
+++ b/Classes/Plugin/DirectMail.php
@@ -735,11 +735,6 @@ class DirectMail extends AbstractPlugin
 
         $theLink = $this->getLink($theLink);
 
-        // remove mailto if it's an email link
-        if (strtolower(substr($theLink, 0, 7)) === 'mailto:') {
-            $theLink = substr($theLink, 7);
-        }
-
         return $this->cObj->getCurrentVal() . ' (###LINK_PREFIX### ' . $theLink . ' )';
     }
 


### PR DESCRIPTION
Email links do not work without mailto.