### PR TITLE
PHP Warning: Undefined array key "jumpurl_tracking_privacy" in DirectMailUtility.php

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -133,7 +133,7 @@ class DirectMailUtility
             $htmlmail->setJumperURLPrefix(
                 $urls['baseUrl'] . $glue .
                 'mid=###SYS_MAIL_ID###' .
-                ((int)$params['jumpurl_tracking_privacy'] ? '' : '&rid=###SYS_TABLE_NAME###_###USER_uid###') .
+                (isset($params['jumpurl_tracking_privacy']) && (int)$params['jumpurl_tracking_privacy'] ? '' : '&rid=###SYS_TABLE_NAME###_###USER_uid###') .
                 '&aC=###SYS_AUTHCODE###' .
                 '&jumpurl='
             );


### PR DESCRIPTION
Because of the error message:
PHP Warning: Undefined array key "jumpurl_tracking_privacy" in /var/www/html/vendor/directmailteam/direct-mail/Classes/DirectMailUtility.php line 136