### PR TITLE
Creation of dynamic property is deprecated in MainController.php

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -133,7 +133,7 @@ class DirectMailUtility
             $htmlmail->setJumperURLPrefix(
                 $urls['baseUrl'] . $glue .
                 'mid=###SYS_MAIL_ID###' .
-                ((int)$params['jumpurl_tracking_privacy'] ? '' : '&rid=###SYS_TABLE_NAME###_###USER_uid###') .
+                (isset($params['jumpurl_tracking_privacy']) && (int)$params['jumpurl_tracking_privacy'] ? '' : '&rid=###SYS_TABLE_NAME###_###USER_uid###') .
                 '&aC=###SYS_AUTHCODE###' .
                 '&jumpurl='
             );

--- a/Classes/Module/MainController.php
+++ b/Classes/Module/MainController.php
@@ -445,7 +445,6 @@ class MainController
         $tree = GeneralUtility::makeInstance(PageTreeView::class);
         $tree->init('AND ' . $perms_clause);
         $tree->makeHTML = 0;
-        $tree->setRecs = 0;
         $tree->getTree($id, $getLevels, '');
 
         return $tree->ids;


### PR DESCRIPTION
error message:
PHP Runtime Deprecation Notice: Creation of dynamic property TYPO3\CMS\Backend\Tree\View\PageTreeView::$setRecs is deprecated in /var/www/html/vendor/directmailteam/direct-mail/Classes/Module/MainController.php line 448