### PR TITLE
[TASK] Mention Direct Mail in subject of admin mail

### DIFF
--- a/Resources/Private/Language/locallang_mod2-6.xlf
+++ b/Resources/Private/Language/locallang_mod2-6.xlf
@@ -371,7 +371,7 @@
 				<source>Job end</source>
 			</trans-unit>
 			<trans-unit id="dmailer_mid" resname="dmailer_mid">
-				<source>Job No:</source>
+				<source>Direct Mail Job No:</source>
 			</trans-unit>
 			<trans-unit id="dmailer_nothing_to_do" resname="dmailer_nothing_to_do">
 				<source>Nothing to do.</source>


### PR DESCRIPTION
**Problem:**
Users are occasionally confused about the purpose of this email notification, as the subject line does not clearly indicate that it refers to a newsletter or Direct Mail job. Without explicit mention, the connection to the Direct Mail system is unclear.

**Suggestion:**
This commit updates the subject line of the admin notification mail from: "Job No: 0000 Job begin"
to:
"Direct Mail Job No: 0000 Job begin"

This change makes the context of the message more recognizable, helping recipients understand that the mail refers to a Direct Mail sending process.